### PR TITLE
Lint fixing

### DIFF
--- a/src/coff_go32.rs
+++ b/src/coff_go32.rs
@@ -57,14 +57,14 @@ pub fn fix_extern_symbol(name: Cow<[u8]>) -> Cow<[u8]> {
             return Cow::from(replacement);
         }
     }
-    return name;
+    name
 }
 
 /// Helper to get the string table from an ElfStream, assuming it exists.  We have to do this in
 /// every new scope because borrow checker.
 fn get_strtab<S: Read + Seek>(
     binary: &mut ElfStream<LittleEndian, S>,
-) -> elf::string_table::StringTable {
+) -> elf::string_table::StringTable<'_> {
     let (_, maybe_strtab) = binary.section_headers_with_strtab().unwrap();
     maybe_strtab.unwrap()
 }
@@ -191,7 +191,7 @@ impl Coff {
         self.symbol_for_elf_symbol_index
             .insert(elf_symbol_index, symbol.clone());
         self.symbols.push(symbol.clone());
-        return Some(symbol);
+        Some(symbol)
     }
 
     pub fn add_relocation(
@@ -459,7 +459,7 @@ impl StringTable {
         }
     }
 
-    pub fn get_name(&self, name: &Name) -> Cow<[u8]> {
+    pub fn get_name(&self, name: &Name) -> Cow<'_, [u8]> {
         match name {
             Name::Literal(s) => Cow::Owned(s.iter().cloned().take_while(|c| *c != b'\0').collect()),
             Name::StringTableIndex(idx) => Cow::Borrowed(self.get_string(*idx)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,11 +162,11 @@ fn output_file(path: &Option<PathBuf>) -> (File, Option<PathBuf>) {
     }
 }
 
-fn convert<S: Read + Seek>(mut binary: &mut ElfStream<LittleEndian, S>) -> Coff {
+fn convert<S: Read + Seek>(binary: &mut ElfStream<LittleEndian, S>) -> Coff {
     let mut coff = Coff::new();
 
     // Add all the sections
-    let sections = get_elf_sections_to_process(&mut binary);
+    let sections = get_elf_sections_to_process(binary);
     for section in sections.values() {
         coff.add_elf_section(
             binary,
@@ -335,10 +335,7 @@ pub fn get_elf_rel_sections<S: Read + Seek>(
     section_headers
         .iter()
         .filter_map(|sh| match sh.sh_type {
-            SHT_REL => Some((
-                strtab.get(sh.sh_name as usize).unwrap().to_owned(),
-                sh.clone(),
-            )),
+            SHT_REL => Some((strtab.get(sh.sh_name as usize).unwrap().to_owned(), *sh)),
             _ => None,
         })
         .collect()


### PR DESCRIPTION
- remove unused trait `CoffSerializer`
- simplify `return «value»;`
- add hidden lifetimes
- remove unnecessary `mut`
- dereference instead of clone where possible
- simplify coff sections checking to use any
- format code